### PR TITLE
重构 Docker 配置：分离前端服务并为 Dockerfile 添加 SQLite 支持

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,42 @@
+# 前端 Nginx 服务 Dockerfile
+FROM node:20-alpine AS frontend-builder
+
+WORKDIR /app/web
+
+# 复制前端依赖文件
+COPY web/package*.json ./
+COPY web/yarn.lock* ./
+
+# 安装前端依赖
+RUN if [ -f yarn.lock ]; then \
+      yarn install --frozen-lockfile; \
+    else \
+      npm ci; \
+    fi
+
+# 复制前端源代码
+COPY web/ ./
+
+# 构建前端（设置后端 URL 环境变量）
+# 使用相对路径，让 nginx 代理转发 API 请求
+ARG BACKEND_URL=http://ytb2bili:8096
+ENV BACKEND_URL=${BACKEND_URL}
+ENV NEXT_PUBLIC_BACKEND_URL=${BACKEND_URL}
+ENV NEXT_PUBLIC_API_URL=/api/v1
+RUN npm run build
+
+# Stage 2: Nginx 运行阶段
+FROM nginx:alpine
+
+# 复制构建好的前端静态文件
+COPY --from=frontend-builder /app/web/output /usr/share/nginx/html
+
+# 复制 nginx 配置文件
+COPY nginx-frontend.conf /etc/nginx/conf.d/default.conf
+
+# 暴露端口
+EXPOSE 80
+
+# 启动 nginx
+CMD ["nginx", "-g", "daemon off;"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,16 +51,16 @@ services:
     networks:
       - ytb2bili-network
 
-  # 可选: Nginx 反向代理
-  nginx:
-    image: nginx:alpine
-    container_name: ytb2bili-nginx
+  # 前端 Nginx 服务（独立于后端）
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
+      args:
+        BACKEND_URL: http://ytb2bili:8096
+    container_name: ytb2bili-frontend
     ports:
       - "80:80"
-      - "443:443"
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./ssl:/etc/ssl/certs:ro
     depends_on:
       - ytb2bili
     restart: unless-stopped

--- a/nginx-frontend.conf
+++ b/nginx-frontend.conf
@@ -1,0 +1,60 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # 启用 gzip 压缩
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/json application/javascript;
+
+    # 前端静态文件服务
+    location / {
+        try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
+    # 静态资源缓存
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # API 请求转发到后端（匹配 /api/v1 路径）
+    location /api/ {
+        proxy_pass http://ytb2bili:8096/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+    }
+
+    # 其他后端路由转发（根据实际 API 路径调整）
+    location ~ ^/(health|auth|video|upload|config|cron|category|subtitle|analytics|submit) {
+        proxy_pass http://ytb2bili:8096;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+    }
+
+    # 错误页面
+    error_page 404 /index.html;
+}
+


### PR DESCRIPTION
## 📋 概述

本次 PR 重构了 Docker 配置，将前端服务独立出来，并为 Dockerfile 中为 Go 后端添加 SQLite 数据库支持。

## 🔧 主要变更

### 后端 Dockerfile
- Go 版本升级至 1.24
- 启用 CGO 并添加 SQLite 构建依赖（gcc, musl-dev, sqlite-dev）
- 运行时添加 sqlite-libs 支持

### 新增前端服务
- **Dockerfile.nginx**: 多阶段构建，使用 Node.js 构建 Next.js 前端，Nginx 提供静态文件服务
- **nginx-frontend.conf**: 前端 Nginx 配置
  - SPA 路由支持
  - API 请求代理到后端（`/api/` 及其他路由）
  - 静态资源缓存优化
  - Gzip 压缩

### Docker Compose
- 将通用 `nginx` 服务替换为专用 `frontend` 服务
- 简化端口映射（仅保留 80 端口）
- 移除 SSL 相关配置

## 🎯 优势

- 前后端服务分离，架构更清晰
- 后端支持 SQLite 数据库
- 前端静态资源缓存优化，性能提升
- 配置简化，更易部署

---

**提交**: `063c6c2f0906623c443faf7cd81807ab4e5261b8`
